### PR TITLE
Let ImGui change the mouse cursor, and fix modifier keys

### DIFF
--- a/src/imgui_wrapper.rs
+++ b/src/imgui_wrapper.rs
@@ -197,21 +197,29 @@ impl ImGuiWrapper {
   }
 
   pub fn update_key_down(&mut self, key: KeyCode, mods: KeyMods) {
-    self.imgui.io_mut().key_shift = mods.contains(KeyMods::SHIFT);
-    self.imgui.io_mut().key_ctrl = mods.contains(KeyMods::CTRL);
-    self.imgui.io_mut().key_alt = mods.contains(KeyMods::ALT);
+    self.imgui.io_mut().key_shift = mods.contains(KeyMods::SHIFT)
+                                    | (key == KeyCode::LShift) | (key == KeyCode::RShift);
+    self.imgui.io_mut().key_ctrl = mods.contains(KeyMods::CTRL)
+                                    | (key == KeyCode::LControl) | (key == KeyCode::RControl);
+    self.imgui.io_mut().key_alt = mods.contains(KeyMods::ALT)
+                                    | (key == KeyCode::LAlt) | (key == KeyCode::RAlt);
+    self.imgui.io_mut().key_super = mods.contains(KeyMods::LOGO)
+                                    | (key == KeyCode::LWin) | (key == KeyCode::RWin);
     self.imgui.io_mut().keys_down[key as usize] = true;
   }
 
-  pub fn update_key_up(&mut self, key: KeyCode, mods: KeyMods) {
-    if mods.contains(KeyMods::SHIFT) {
+  pub fn update_key_up(&mut self, key: KeyCode, _mods: KeyMods) {
+    if (key == KeyCode::LShift) | (key == KeyCode::RShift) {
       self.imgui.io_mut().key_shift = false;
     }
-    if mods.contains(KeyMods::CTRL) {
+    if (key == KeyCode::LControl) | (key == KeyCode::RControl) {
       self.imgui.io_mut().key_ctrl = false;
     }
-    if mods.contains(KeyMods::ALT) {
+    if (key == KeyCode::LAlt) | (key == KeyCode::RAlt) {
       self.imgui.io_mut().key_alt = false;
+    }
+    if (key == KeyCode::LWin) | (key == KeyCode::RWin) {
+      self.imgui.io_mut().key_super = false;
     }
     self.imgui.io_mut().keys_down[key as usize] = false;
   }

--- a/src/imgui_wrapper.rs
+++ b/src/imgui_wrapper.rs
@@ -1,6 +1,7 @@
 use ggez::event::{KeyCode, KeyMods, MouseButton};
 use ggez::graphics;
 use ggez::Context;
+use ggez::input::mouse;
 
 use gfx_core::{handle::RenderTargetView, memory::Typed};
 use gfx_device_gl;
@@ -9,6 +10,20 @@ use imgui::*;
 use imgui_gfx_renderer::*;
 
 use std::time::Instant;
+
+fn to_winit_cursor(cursor: imgui::MouseCursor) -> mouse::MouseCursor {
+  match cursor {
+    imgui::MouseCursor::Arrow      => mouse::MouseCursor::Arrow,
+    imgui::MouseCursor::TextInput  => mouse::MouseCursor::Text,
+    imgui::MouseCursor::ResizeAll  => mouse::MouseCursor::Move,
+    imgui::MouseCursor::ResizeNS   => mouse::MouseCursor::NsResize,
+    imgui::MouseCursor::ResizeEW   => mouse::MouseCursor::EwResize,
+    imgui::MouseCursor::ResizeNESW => mouse::MouseCursor::NeswResize,
+    imgui::MouseCursor::ResizeNWSE => mouse::MouseCursor::NwseResize,
+    imgui::MouseCursor::Hand       => mouse::MouseCursor::Hand,
+    imgui::MouseCursor::NotAllowed => mouse::MouseCursor::NotAllowed,
+  }
+}
 
 #[derive(Copy, Clone, PartialEq, Debug, Default)]
 struct MouseState {
@@ -117,6 +132,14 @@ impl ImGuiWrapper {
           ui.text(im_str!("Hi from this label!"));
         });
       ui.show_demo_window(&mut show);
+    }
+
+    // Update the mouse cursor
+    if let Some(cursor) = ui.mouse_cursor() {
+      mouse::set_cursor_hidden(ctx, false);
+      mouse::set_cursor_type(ctx, to_winit_cursor(cursor));
+    } else {
+      mouse::set_cursor_hidden(ctx, true);
     }
 
     // Render


### PR DESCRIPTION
This allows the mouse cursor to change when hovering over certain GUI elements such as text boxes and the corners of resizable windows. You can test all the different cursors by going to the "Inputs, Navigation & Focus"->"Mouse Cursors" section of the ImGui demo window.

I also noticed that it was impossible to ctrl+click on widgets because the modifier key state was only updated correctly when another key was held down. I changed that logic, and you can test it in the "Inputs, Navigation & Focus"->"Keyboard, Mouse & Navigation State" section. I think it can still break if the window loses focus while keys are being held down. There's a focus_event in ggez so maybe it would be a good idea to clear all keyboard state whenever the window loses focus, but I'm not sure.